### PR TITLE
Added TX Frequencies for APX Portable Radios

### DIFF
--- a/OpenAutoBench-ng/Communication/Radio/Motorola/APX/MotorolaAPX_Frequencies.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/APX/MotorolaAPX_Frequencies.cs
@@ -11,8 +11,10 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.APX
              * PORTABLES
              */
 
-            // 900 APX4000
-            if (radio.ModelNumber.Contains("H51W"))
+            //900 APX4000
+            if (radio.ModelNumber.Contains("H51W") ||
+                // 900 APX1000
+                radio.ModelNumber.Contains("H84W"))
             {
                 TxFrequencies.Add(896012500);
                 TxFrequencies.Add(899012500);
@@ -37,10 +39,18 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.APX
                 TxFrequencies.Add(940987500);
             }
 
-                     // 7/800 APX900
+            // 7/800 APX900
             else if (radio.ModelNumber.Contains("H92U") ||
-                     // 7/800 APX6000AN
-                     radio.ModelNumber.Contains("H98U"))
+                // 7/8000 APX1000
+                radio.ModelNumber.Contains("H84U") ||
+                // 7/800 APX2000
+                radio.ModelNumber.Contains("H52U") ||
+                // 7/800 APX3000
+                radio.ModelNumber.Contains("H59U") ||
+                // 7/800 APX4000
+                radio.ModelNumber.Contains("H51U") ||
+                // 7/800 APX 5000 & APX6000
+                radio.ModelNumber.Contains("H98U"))
             {
                 TxFrequencies.Add(764012500);
                 TxFrequencies.Add(769012500);
@@ -53,10 +63,30 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.APX
                 TxFrequencies.Add(869887500);
             }
 
-                     // UHF2 APX4000
-            else if (radio.ModelNumber.Contains("H51S") ||
-                     // UHF2 APX6000AN
-                     radio.ModelNumber.Contains("H98S"))
+            //UHF2 APX 900
+            else if (radio.ModelNumber.Contains("H92S"))
+            {
+                TxFrequencies.Add(450025000);
+                TxFrequencies.Add(460025000);
+                TxFrequencies.Add(470000000);
+                TxFrequencies.Add(470005000);
+                TxFrequencies.Add(485025000);
+                TxFrequencies.Add(495025000);
+                TxFrequencies.Add(500025000);
+                TxFrequencies.Add(510025000);
+                TxFrequencies.Add(519975000);
+            }
+
+            //UHF2 APX1000
+            else if (radio.ModelNumber.Contains("H84S") ||
+                // UHF2 APX2000
+                radio.ModelNumber.Contains("H52S") ||
+                //UHF2 APX3000
+                radio.ModelNumber.Contains("H59S") ||
+                //UHF2 APX4000
+                radio.ModelNumber.Contains("H51S") ||
+                // UHF2 APX5000 & APX6000
+                radio.ModelNumber.Contains("H98S"))
             {
                 TxFrequencies.Add(450025000);
                 TxFrequencies.Add(460025000);
@@ -65,11 +95,32 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.APX
                 TxFrequencies.Add(485025000);
                 TxFrequencies.Add(495025000);
                 TxFrequencies.Add(506025000);
-                TxFrequencies.Add(511975000);
+                TxFrequencies.Add(519750000);
             }
 
-            // UHF1 APX3000
-            else if (radio.ModelNumber.Contains("H59Q"))
+            //UHF1 APX900
+            else if (radio.ModelNumber.Contains("H92Q"))
+            {
+                TxFrequencies.Add(380025000);
+                TxFrequencies.Add(392525000);
+                TxFrequencies.Add(405025000);
+                TxFrequencies.Add(417525000);
+                TxFrequencies.Add(429925000);
+                TxFrequencies.Add(430025000);
+                TxFrequencies.Add(442525000);
+                TxFrequencies.Add(455025000);
+                TxFrequencies.Add(467525000);
+                TxFrequencies.Add(479925000);
+            }
+
+            // UHF1 APX1000
+            else if (radio.ModelNumber.Contains("H84Q") ||
+                //UHF1 APX2000
+                radio.ModelNumber.Contains("H52Q") ||
+                //UHF1 APX3000
+                radio.ModelNumber.Contains("H59Q") ||
+                //UHF1 APX4000
+                radio.ModelNumber.Contains("H51Q"))
             {
                 TxFrequencies.Add(380025000);
                 TxFrequencies.Add(390025000);
@@ -81,6 +132,41 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.APX
                 TxFrequencies.Add(445025000);
                 TxFrequencies.Add(457025000);
                 TxFrequencies.Add(469925000);
+            }
+
+            //UHF1 APX5000 & APX6000
+            else if (radio.ModelNumber.Contains("H98Q"))
+            {
+                TxFrequencies.Add(380025000);
+                TxFrequencies.Add(395025000);
+                TxFrequencies.Add(411025000);
+                TxFrequencies.Add(424925000);
+                TxFrequencies.Add(425025000);
+                TxFrequencies.Add(440025000);
+                TxFrequencies.Add(455325000);
+                TxFrequencies.Add(469925000);
+                TxFrequencies.Add(479925000);
+            }
+
+            //VHF APX900
+            else if (radio.ModelNumber.Contains("H92K") ||
+                //VHF APX1000
+                radio.ModelNumber.Contains("H84K") ||
+                //VHF APX2000
+                radio.ModelNumber.Contains("H52K") ||
+                //VHF APX3000
+                radio.ModelNumber.Contains("H59K") ||
+                //VHF APX4000
+                radio.ModelNumber.Contains("H51K") ||
+                //VHF APX5000 & APX6000
+                radio.ModelNumber.Contains("H98K"))
+            {
+                TxFrequencies.Add(136025000);
+                TxFrequencies.Add(142125000);
+                TxFrequencies.Add(154225000);
+                TxFrequencies.Add(160125000);
+                TxFrequencies.Add(168075000);
+                TxFrequencies.Add(173975000);
             }
 
             /*
@@ -120,7 +206,17 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.APX
 
                 if (bands.Contains(MotorolaBand.BAND_UHF1))
                 {
-                    throw new Exception("I don't know your 7000's frequencies");
+                    TxFrequencies.Add(380025000);
+                    TxFrequencies.Add(390025000);
+                    TxFrequencies.Add(400025000);
+                    TxFrequencies.Add(411025000);
+                    TxFrequencies.Add(424925000);
+                    TxFrequencies.Add(435025000);
+                    TxFrequencies.Add(444975000);
+                    TxFrequencies.Add(445025000);
+                    TxFrequencies.Add(457025000);
+                    TxFrequencies.Add(469925000);
+
                 }
 
                 if (bands.Contains(MotorolaBand.BAND_VHF))


### PR DESCRIPTION
Added TX Frequencies for the entire line of APX portable radios.

Information was obtained by consulting Motorola Basic Service manuals, test were conducted for the radios I have on hand.