### PR TITLE
BugFix - Extended test default Settings are causing an infinite loop

### DIFF
--- a/OpenAutoBench-ng/Communication/Instrument/Astronics_R8000/Astronics_R8000Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/Astronics_R8000/Astronics_R8000Instrument.cs
@@ -70,6 +70,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.Astronics_R8000
 
             if (status != currStatus)
             {
+                await Task.Delay(500);
                 await Send("DO RF:RF Power");
             }
             await Task.Delay(500);

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/XCMPRadioTestParams.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/XCMPRadioTestParams.cs
@@ -14,8 +14,8 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
 
         // extended tests
 
-        public bool doRxExtendedTest = true;
-        public bool doTxExtendedTest = true;
+        public bool doRxExtendedTest = false;
+        public bool doTxExtendedTest = false;
 
         public int ExtendedTestStart = 0;
         public int ExtendedTestEnd = 0;


### PR DESCRIPTION
The default value for doRxExtendedTest & doTxExtendedTest settings were set to true. The Extended test settings are only visible when a user has chosen to enable them in the danger mode settings. 

For users who do not enable them in the danger mode settings, the checkbox and fields are invisible on the test page, With the default values, the tests are ending up causing an infinite loop since the default value for ExtendedTestStart, ExtendedTestEnd & ExtendedTestStep are all 0. 

I am changing the ExtendedTests settings so they are disabled by default. 
