### PR TITLE
BugFix - Aeroflex IFR 2975 TX Deviation

### DIFF
--- a/OpenAutoBench-ng/Communication/Instrument/Astronics_R8000/Astronics_R8000Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/Astronics_R8000/Astronics_R8000Instrument.cs
@@ -70,6 +70,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.Astronics_R8000
 
             if (status != currStatus)
             {
+                await Task.Delay(500);
                 await Send("DO RF:RF Power");
             }
             await Task.Delay(500);

--- a/OpenAutoBench-ng/Communication/Instrument/IFR_2975/IFR_2975Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/IFR_2975/IFR_2975Instrument.cs
@@ -84,7 +84,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.IFR_2975
 
         public async Task<float> MeasureFMDeviation()
         {
-            return float.Parse(await Send("FMDev VALue"));
+            return float.Parse(await Send("FMDev VALue"))*1000F;
         }
 
         public async Task<string> GetInfo()


### PR DESCRIPTION
The Aeroflex IFR 2975 returns the FM Deviation value in KHz, however the unit used when displaying results is Hz. Fixed the unit conversion issue by multiplying what the Aeroflex returns by 1000, to bring back the value in Hz.