### PR TITLE
Improvements - TX Deviation Tests

### DIFF
--- a/OpenAutoBench-ng/Communication/Instrument/Astronics_R8000/Astronics_R8000Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/Astronics_R8000/Astronics_R8000Instrument.cs
@@ -70,6 +70,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.Astronics_R8000
 
             if (status != currStatus)
             {
+                await Task.Delay(500);
                 await Send("DO RF:RF Power");
             }
             await Task.Delay(500);

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_DeviationBalance.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_DeviationBalance.cs
@@ -56,14 +56,14 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                 {
                     int currFreq = TXFrequencies[i];
                     Radio.SetTXFrequency(currFreq, false);
-                    Instrument.SetRxFrequency(currFreq);
+                    await Instrument.SetRxFrequency(currFreq);
                     // low tone
                     Radio.SetTransmitConfig(XCMPRadioTransmitOption.DEVIATION_LOW);
                     Radio.Keyup();
                     await Task.Delay(5000);
-                    float measDev = await Instrument.MeasureFMDeviation();
-                    measDev = (float)Math.Round(measDev, 2);
-                    LogCallback(String.Format("TX Deviation Point at {0}MHz (low tone): {1}hz", (currFreq / 1000000F), measDev));
+                    float measDevLow = await Instrument.MeasureFMDeviation();
+                    measDevLow = (float)Math.Round(measDevLow);
+                    LogCallback(String.Format("TX Deviation Point at {0}MHz (low tone): {1}hz", (currFreq / 1000000F), measDevLow));
                     Radio.Dekey();
                     await Task.Delay(1000);
 
@@ -71,10 +71,14 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                     Radio.SetTransmitConfig(XCMPRadioTransmitOption.DEVIATION_HIGH);
                     Radio.Keyup();
                     await Task.Delay(5000);
-                    measDev = await Instrument.MeasureFMDeviation();
-                    measDev = (float)Math.Round(measDev, 2);
-                    LogCallback(String.Format("TX Deviation Point at {0}MHz (high tone): {1}hz", (currFreq / 1000000F), measDev));
+                    float measDevHigh = await Instrument.MeasureFMDeviation();
+                    measDevHigh = (float)Math.Round(measDevHigh);
+                    LogCallback(String.Format("TX Deviation Point at {0}MHz (high tone): {1}hz", (currFreq / 1000000F), measDevHigh));
                     Radio.Dekey();
+
+                    // percentage difference
+                    float percentDifference = (measDevHigh - measDevLow) / measDevLow * 100;
+                    LogCallback(String.Format("Variance between high tone and low tone at {0}MHz: {1}%", (currFreq / 1000000F), Math.Round(percentDifference, 2)));
                     await Task.Delay(1000);
                 }
             }


### PR DESCRIPTION
The deviation was previously reported in Hz, with two decimal places (in 1/100th of a Hz). I've changed the rounding so the deviation is rounded in Hz since none of the supported instruments can provide this level of accuracy.

For reference, the data sheets of the  supported instruments show the following FM deviation measurement resolution/accuracy:

HP 8920: 20Hz Resolution (no accuracy specified)
IFR 2975 : 10Hz Resolution (with a +/- 3% to 5% accuracy)
R8000: 1Hz Resolution (with a +/- 5% accuracy)
Viavi 8800: 1Hz Resolution (with a +/- 5% to +/- 10% accuracy)

I also added a feature that computes the difference between the high tone deviation and the low tone deviation in percent, and added it to the test output.
