### PR TITLE
Instrument Setup Functions

### DIFF
--- a/OpenAutoBench-ng/Communication/Instrument/Astronics_R8000/Astronics_R8000Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/Astronics_R8000/Astronics_R8000Instrument.cs
@@ -155,12 +155,6 @@ namespace OpenAutoBench_ng.Communication.Instrument.Astronics_R8000
             await Task.Delay(5000);
         }
 
-        public async Task SetupFiltersForDeviation()
-        {
-            //await Transmit("AFAN:FILT1 '<20Hz HPF'");
-            //await Transmit("AFAN:FILT2 '15kHz LPF'");
-        }
-
         public async Task<float> MeasureP25RxBer()
         {
             await Send("GO SYSTEM:P25");
@@ -180,5 +174,36 @@ namespace OpenAutoBench_ng.Communication.Instrument.Astronics_R8000
             await Task.Delay(5000);
             await Send("SET P25:BER Test=Start");
         }
+
+        public async Task SetupRefOscillatorTest_P25()
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
+
+        public async Task SetupRefOscillatorTest_FM()
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
+
+        public async Task SetupTXPowerTest()
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
+
+        public async Task SetupTXDeviationTest()
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
+
+        public async Task SetupTXP25BERTest()
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
+
+        public async Task SetupExtendedRXTest()
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
     }
 }
+

--- a/OpenAutoBench-ng/Communication/Instrument/GeneralDynamics_R2670/GeneralDynamics_R2670Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/GeneralDynamics_R2670/GeneralDynamics_R2670Instrument.cs
@@ -99,11 +99,6 @@ namespace OpenAutoBench_ng.Communication.Instrument.GeneralDynamics_R2670
             throw new NotImplementedException();
         }
 
-        public async Task SetupFiltersForDeviation()
-        {
-            throw new NotImplementedException();
-        }
-
         public Task<float> MeasureP25RxBer()
         {
             throw new NotImplementedException();
@@ -163,5 +158,36 @@ namespace OpenAutoBench_ng.Communication.Instrument.GeneralDynamics_R2670
             }
             return valList.ToArray();
         }
+
+        public async Task SetupRefOscillatorTest_P25()
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
+
+        public async Task SetupRefOscillatorTest_FM()
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
+
+        public async Task SetupTXPowerTest()
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
+
+        public async Task SetupTXDeviationTest()
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
+
+        public async Task SetupTXP25BERTest()
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task SetupExtendedRXTest()
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
     }
 }
+

--- a/OpenAutoBench-ng/Communication/Instrument/HP_8900/HP_8900Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/HP_8900/HP_8900Instrument.cs
@@ -126,12 +126,6 @@ namespace OpenAutoBench_ng.Communication.Instrument.HP_8900
             }
         }
 
-        public async Task SetupFiltersForDeviation()
-        {
-            await Transmit("AFAN:FILT1 '<20Hz HPF'");
-            await Transmit("AFAN:FILT2 '15kHz LPF'");
-        }
-
         public Task<float> MeasureP25RxBer()
         {
             throw new NotImplementedException("HP 8900 does not support digital tests.");
@@ -150,6 +144,38 @@ namespace OpenAutoBench_ng.Communication.Instrument.HP_8900
         public Task ResetBERErrors()
         {
             throw new NotImplementedException();
+        }
+
+        public async Task SetupRefOscillatorTest_P25()
+        {
+           //Not implemented, but shouldn't raise an exception
+        }
+
+        public async Task SetupRefOscillatorTest_FM()
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
+
+        public async Task SetupTXPowerTest()
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
+
+        public async Task SetupTXDeviationTest()
+        {
+            //Partially implemented, the filters are being set-up, but other settings may need to be added.
+            await Transmit("AFAN:FILT1 '<20Hz HPF'");
+            await Transmit("AFAN:FILT2 '15kHz LPF'");
+        }
+
+        public async Task SetupTXP25BERTest()
+        {
+            throw new NotImplementedException("HP 8900 does not support digital tests.");
+        }
+
+        public async Task SetupExtendedRXTest()
+        {
+            //Not implemented, but shouldn't raise an exception
         }
     }
 }

--- a/OpenAutoBench-ng/Communication/Instrument/IBaseInstrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/IBaseInstrument.cs
@@ -32,12 +32,22 @@
 
         public Task SetDisplay(InstrumentScreen screen);
 
-        public Task SetupFiltersForDeviation();
-
         public Task<float> MeasureP25RxBer();
 
         public Task<float> MeasureDMRRxBer();
 
         public Task ResetBERErrors();
+
+        public Task SetupRefOscillatorTest_P25();
+
+        public Task SetupRefOscillatorTest_FM();
+
+        public Task SetupTXPowerTest();
+
+        public Task SetupTXDeviationTest();
+
+        public Task SetupTXP25BERTest();
+
+        public Task SetupExtendedRXTest();
     }
 }

--- a/OpenAutoBench-ng/Communication/Instrument/IFR_2975/IFR_2975Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/IFR_2975/IFR_2975Instrument.cs
@@ -42,24 +42,30 @@ namespace OpenAutoBench_ng.Communication.Instrument.IFR_2975
         }
 
         public async Task GenerateSignal(float power)
-        {
+        { 
+            
             await Send($"Generator RFLEVel {power.ToString()}");
+            await Task.Delay(1000);
+            await Send("Generator PTT 1");
         }
 
         public async Task GenerateFMSignal(float power, float afFreq)
         {
+            //implementation to review
             await GenerateSignal(power);
             await Send("Generator MODulation 1");
+            await Send($"Generator RFLEVel {power.ToString()}");
         }
+            
 
-        public Task StopGenerating()
+        public async Task StopGenerating()
         {
-            throw new NotImplementedException();
+            await Send("Generator PTT 0");
         }
 
         public async Task SetGenPort(InstrumentOutputPort outputPort)
         {
-            throw new NotImplementedException();
+            await Send("Generator RFOUTput 0"); // Set Generator port to T/R
         }
 
         public async Task SetRxFrequency(int frequency)
@@ -84,7 +90,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.IFR_2975
 
         public async Task<float> MeasureFMDeviation()
         {
-            return float.Parse(await Send("FMDev VALue"))*1000F;
+            return float.Parse(await Send("FMDev VALue")) * 1000F;
         }
 
         public async Task<string> GetInfo()
@@ -102,12 +108,6 @@ namespace OpenAutoBench_ng.Communication.Instrument.IFR_2975
             //await Transmit("DISP " + displayName);
         }
 
-        public async Task SetupFiltersForDeviation()
-        {
-            //await Transmit("AFAN:FILT1 '<20Hz HPF'");
-            //await Transmit("AFAN:FILT2 '15kHz LPF'");
-        }
-
         public async Task<float> MeasureP25RxBer()
         {
             string resp = await Send("Ber READING");
@@ -123,6 +123,80 @@ namespace OpenAutoBench_ng.Communication.Instrument.IFR_2975
         public async Task ResetBERErrors()
         {
             await Send("Ber RESETERRors");
+        }
+
+        public async Task SetupRefOscillatorTest_P25()
+        {
+            await Send("Receiver DEMODulation 14"); // P25 Wide Band
+            await Send("Receiver FILter 0"); // No DEMOD Filter
+            await Send("Receiver RFINput 0"); // Set Receiver to T/R Port
+            await Send("Receiver IFGAIN 0"); // No gain applied on signal
+            await Send("Receiver ATTENuation 20"); // 20db Attenuation on the receiver
+            await Send("RFError AVG 10"); // Set up the RF Error to a 10 sample average
+            await Send("RFError ENable 3"); // Enable RF Error meter
+        }
+
+        public async Task SetupRefOscillatorTest_FM()
+        {
+            await Send("Receiver ATTENuation 20"); // 20db Attenuation on the receiver
+            await Send("Receiver DEMODulation 10"); // FM Wide Band
+            await Send("Receiver FILter 0"); // No DEMOD Filter
+            await Send("Receiver RFINput 0"); // Set Receiver to T/R Port
+            await Send("Receiver IFGAIN 0"); // No gain applied on signal
+            await Send("Receiver ATTENuation 20"); // 20db Attenuation on the receiver
+            await Send("RFError AVG 10"); // Set up the RF Error to a 10 sample average
+            await Send("RFError ENable 3"); // Enable RF Error meter
+        }
+
+        public async Task SetupTXPowerTest()
+        {
+            await Send("Receiver DEMODulation 11"); // No Demodulation
+            await Send("Receiver FILter 0"); // No DEMOD Filter
+            await Send("Receiver RFINput 0"); // Set Receiver to T/R Port
+            await Send("Receiver IFGAIN 0"); // No gain applied on signal
+            await Send("Receiver ATTENuation 20"); // 20db Attenuation on the receiver
+            await Send("Power ENable On"); // Enable power meter
+            await Send("Power ZERO"); // Zero the power meter while no signal is applied
+            await Send("Power prange 0"); // Set the meter to auto range
+        }
+
+        public async Task SetupTXDeviationTest()
+        {
+            await Send("Receiver DEMODulation 3"); //  FM 60 kHz DEMOD.
+            await Send("Receiver RFINput 0"); // Set Receiver to T/R Port 
+            await Send("Receiver IFGAIN 0"); // No gain applied on signal
+            await Send("Receiver FILter 4"); // 15 kHz Low-Pass
+            await Send("Receiver ATTENuation 20"); // 20db Attenuation on the receiver
+            await Send("FMDev Enable 3"); // Enable the deviation meter
+            await Send("FMDev MATH 1"); //Average
+            await Send("FMDev AVG 200"); //Number of samples for the averaging
+            await Send("FMDev RUN 1"); //Indicate to the meter to start running continuous collection
+        }
+
+        public async Task SetupTXP25BERTest()
+        {
+            await Send("Receiver DEMODulation 14"); // P25 Wide Band
+            await Send("Receiver RFINput 0"); // Set Receiver to T/R Port 
+            await Send("Receiver IFGAIN 0"); // No gain applied on signal
+            await Send("Receiver FILter 4"); // 15 kHz Low-Pass
+            await Send("Receiver ATTENuation 20"); // 20db Attenuation on the receiver
+            await Send("Ber ENable 3"); // Enable BER meter
+            await Send("Ber FRAMES 8"); // Sample size of 8 frames
+            await Send("Ber PATTERN 0"); // Standars 1011 P25 Test Pattern
+            await Send("Ber PEAKhold 0"); // Disable peak mode
+            await Send("Ber RUN 1"); // Indicate to the BER Meter to start continuous collection
+            await Send("Ber RESETErrors"); // Reset Error counter
+        }
+
+        public async Task SetupExtendedRXTest()
+        {
+            await Send("Generator RFOUTput 0"); // Set Generator to T/R Port
+            await Send("Generator DCPOWer 1"); // Turn Generator Mode On
+            await Send("Generator PTT 0"); // Sets the Generator to Off
+            await Send("FGen MODe3 1");  //Set Function Generator to Tone injection mode
+            await Send("FGen Freq3 1000"); // 1KHz Tone Modulation
+            await Send("FGen Dev3 3"); // 3kHz Deviation
+            await Send("FGen SH3 0"); // Sine audio wave shape
         }
     }
 }

--- a/OpenAutoBench-ng/Communication/Instrument/Viavi_8800SX/Viavi_8800SXInstrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/Viavi_8800SX/Viavi_8800SXInstrument.cs
@@ -109,12 +109,6 @@ namespace OpenAutoBench_ng.Communication.Instrument.Viavi_8800SX
             //await Transmit("DISP " + displayName);
         }
 
-        public async Task SetupFiltersForDeviation()
-        {
-            //await Transmit("AFAN:FILT1 '<20Hz HPF'");
-            //await Transmit("AFAN:FILT2 '15kHz LPF'");
-        }
-
         public async Task<float> MeasureP25RxBer()
         {
             throw new NotImplementedException();
@@ -132,6 +126,36 @@ namespace OpenAutoBench_ng.Communication.Instrument.Viavi_8800SX
         {
             throw new NotImplementedException();
             //await Send("Ber RESETERRors");
+        }
+
+        public async Task SetupRefOscillatorTest_P25()
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
+
+        public async Task SetupRefOscillatorTest_FM()
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
+
+        public async Task SetupTXPowerTest()
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
+
+        public async Task SetupTXDeviationTest()
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
+
+        public async Task SetupTXP25BERTest()
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task SetupExtendedRXTest()
+        {
+            //Not implemented, but shouldn't raise an exception
         }
     }
 }

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/RSSRepeaterBase/MotorolaRSSRepeater_TestTX_Deviation.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/RSSRepeaterBase/MotorolaRSSRepeater_TestTX_Deviation.cs
@@ -39,7 +39,9 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.RSSRepeaterBase
         public async Task setup()
         {
             await Instrument.SetDisplay(InstrumentScreen.Monitor);
-            await Instrument.SetupFiltersForDeviation();
+            await Task.Delay(1000);
+            await Instrument.SetupTXDeviationTest();
+            await Task.Delay(1000);
         }
 
         public async Task performTest()

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_ExtendedFreq.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_ExtendedFreq.cs
@@ -47,6 +47,8 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
             LogCallback(String.Format("Setting up for {0}", name));
             await Instrument.SetDisplay(InstrumentScreen.Generate);
             await Task.Delay(1000);
+            await Instrument.SetupExtendedRXTest();
+            await Task.Delay(1000);
         }
 
         public async Task performTest()
@@ -59,7 +61,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                     Radio.SetRXFrequency(i, false);
                     await Instrument.SetTxFrequency(i);
                     await Task.Delay(5000);
-                    await Instrument.GenerateSignal(-80);
+                    await Instrument.GenerateSignal(-47);
                     await Task.Delay(5000);
                     byte[] rssi = Radio.GetStatus(MotorolaXCMPRadioBase.StatusOperation.RSSI);
                     await Instrument.StopGenerating();

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_DeviationBalance.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_DeviationBalance.cs
@@ -44,7 +44,8 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
         {
             LogCallback(String.Format("Setting up for {0}", name));
             await Instrument.SetDisplay(InstrumentScreen.Monitor);
-            await Instrument.SetupFiltersForDeviation();
+            await Task.Delay(1000);
+            await Instrument.SetupTXDeviationTest();
             await Task.Delay(1000);
         }
 
@@ -60,7 +61,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                     // low tone
                     Radio.SetTransmitConfig(XCMPRadioTransmitOption.DEVIATION_LOW);
                     Radio.Keyup();
-                    await Task.Delay(5000);
+                    await Task.Delay(10000);
                     float measDevLow = await Instrument.MeasureFMDeviation();
                     measDevLow = (float)Math.Round(measDevLow);
                     LogCallback(String.Format("TX Deviation Point at {0}MHz (low tone): {1}hz", (currFreq / 1000000F), measDevLow));
@@ -70,7 +71,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                     // high tone
                     Radio.SetTransmitConfig(XCMPRadioTransmitOption.DEVIATION_HIGH);
                     Radio.Keyup();
-                    await Task.Delay(5000);
+                    await Task.Delay(10000);
                     float measDevHigh = await Instrument.MeasureFMDeviation();
                     measDevHigh = (float)Math.Round(measDevHigh);
                     LogCallback(String.Format("TX Deviation Point at {0}MHz (high tone): {1}hz", (currFreq / 1000000F), measDevHigh));

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_P25_BER.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_P25_BER.cs
@@ -44,6 +44,8 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
             LogCallback(String.Format("Setting up for {0}", name));
             await Instrument.SetDisplay(InstrumentScreen.Monitor);
             await Task.Delay(1000);
+            await Instrument.SetupTXP25BERTest();
+            await Task.Delay(1000);
 
             // let child set frequency
         }

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_PowerCharacterization.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_PowerCharacterization.cs
@@ -48,7 +48,8 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
             LogCallback(String.Format("Setting up for {0}", name));
             await Instrument.SetDisplay(InstrumentScreen.Monitor);
             await Task.Delay(1000);
-
+            await Instrument.SetupTXPowerTest();
+            await Task.Delay(1000);
             CharPoints = Radio.GetTXPowerPoints();
         }
 

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_ReferenceOscillator.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_ReferenceOscillator.cs
@@ -44,6 +44,8 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
             LogCallback(String.Format("Setting up for {0}", name));
             await Instrument.SetDisplay(InstrumentScreen.Monitor);
             await Task.Delay(1000);
+            await Instrument.SetupRefOscillatorTest_P25();
+            await Task.Delay(1000);
 
             // let child set frequency
         }


### PR DESCRIPTION
Implemented setup function for each tests to set-up the instrument in the proper state prior to begin a test. Fully implemented for Aeroflex IFR 2975, placeholder functions were created for other instruments.

The test set-up parameters were validated against Serveral Motorola Basic Service Monitors to ensure proper testing methodology.

Adjusted the waiting period for the TX Deviation test, instruments need to average out and it takes some time for the value to stabilize.