### PR TITLE
APX "AN" Compatibility & Bug Fixes

### DIFF
--- a/OpenAutoBench-ng/Communication/Instrument/Connection/SerialConnection.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/Connection/SerialConnection.cs
@@ -18,8 +18,8 @@ namespace OpenAutoBench_ng.Communication.Instrument.Connection
         {
             _serialPort = new SerialPort(portName);
             _serialPort.BaudRate = baudrate;
-            // set 3sec timeout
-            _serialPort.ReadTimeout = 3000;
+            // set 5sec timeout
+            _serialPort.ReadTimeout = 5000;
             switch (delimeter)
             {
                 case Settings.SerialNewlineType.LF:
@@ -33,7 +33,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.Connection
                     break;
             }
             _serialPort.DtrEnable = useDTR;
-            // _serialPort.RtsEnable = true;//this is needed for R2670
+
 
         }
 

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/APX/MotorolaAPX.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/APX/MotorolaAPX.cs
@@ -134,12 +134,6 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.APX
                 await test.Teardown();
             }
         }
-
-        public override int[] GetTXPowerPoints()
-        {
-            Console.WriteLine($"XCMP: reading APX TX power characterization frequencies");
-            return SoftpotReadAllFrequencies(SoftpotType.TxPowerCharPoint);
-        }
         
         public override void SetTransmitPower(TxPowerLevel power)
         {

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/APX/MotorolaAPX_RefData.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/APX/MotorolaAPX_RefData.cs
@@ -383,5 +383,22 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.APX
 
             return TxFrequencies.ToArray();
         }
+
+        public static bool isFreon(MotorolaXCMPRadioBase radio)
+        {
+            if (
+                radio.ModelNumber.EndsWith("BN") ||
+                radio.ModelNumber.EndsWith("CN") ||
+                //APX900
+                radio.ModelNumber.StartsWith("H92") ||
+                //APX8000
+                radio.ModelNumber.StartsWith("H91") ||
+                //APX8500
+                radio.ModelNumber.StartsWith("H91"))
+            {
+                return true;
+            }
+            return false;
+        }
     }
 }

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/APX/MotorolaAPX_TestTX_DeviationBalance.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/APX/MotorolaAPX_TestTX_DeviationBalance.cs
@@ -8,5 +8,39 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.APX
         {
             //
         }
+
+        public async Task Setup()
+        {
+            await base.Setup();
+
+            LogCallback(String.Format("Setting up for {0}", Name));
+
+            if (MotorolaAPX_RefData.isFreon(Radio))
+            {
+                ModBalParams = Radio.SoftpotGetParams(SoftpotType.ModBalance);
+            }
+            else
+            {
+                int[] frequencies = MotorolaAPX_RefData.TxFrequencies(Radio);
+
+                ModBalParams.Frequencies = new int[frequencies.Length];
+                ModBalParams.Frequencies = frequencies;
+
+                ModBalParams.Min = MotorolaXCMPRadioBase.SoftpotBytesToValue(Radio.SoftpotGetMinimum(SoftpotType.ModBalance));
+                ModBalParams.Max = MotorolaXCMPRadioBase.SoftpotBytesToValue(Radio.SoftpotGetMaximum(SoftpotType.ModBalance));
+
+                ModBalParams.ByteLength = 2;
+
+                ModBalParams.Values = new int[frequencies.Length];
+
+                List<byte[]> softpotList = Radio.SoftpotReadAll(SoftpotType.ModBalance, ModBalParams.ByteLength);
+                for (int i = 0; i < softpotList.Count; i++)
+                {
+                    ModBalParams.Values[i] = MotorolaXCMPRadioBase.SoftpotBytesToValue(softpotList[i]);
+                }
+
+
+            }
+        }
     }
 }

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/APX/MotorolaAPX_TestTX_PowerCharacterization.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/APX/MotorolaAPX_TestTX_PowerCharacterization.cs
@@ -12,7 +12,31 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.APX
         public override async Task Setup()
         {
             await base.Setup();
-            TXFrequencies = MotorolaAPX_RefData.TxFrequencies(Radio);
+            if (MotorolaAPX_RefData.isFreon(Radio))
+            {
+                txPwrCharPoints = Radio.SoftpotGetParams(SoftpotType.TxPowerCharPoint);
+            }
+            else
+            {
+                int[] frequencies = MotorolaAPX_RefData.TxFrequencies(Radio);
+
+                txPwrCharPoints.Frequencies = new int[frequencies.Length*2];
+                txPwrCharPoints.Frequencies = frequencies;
+
+                //Has to be hardcoded, getMin and getMax OP_CODES not supported for this softpot type
+                txPwrCharPoints.Min = 0;
+                txPwrCharPoints.Max = 4095;
+
+                txPwrCharPoints.ByteLength = 2;
+
+                txPwrCharPoints.Values = new int[frequencies.Length*2];
+
+                List<byte[]> softpotList = Radio.SoftpotReadAll(SoftpotType.TxPowerCharPoint, txPwrCharPoints.ByteLength);
+                for (int i = 0; i < softpotList.Count; i++)
+                {
+                    txPwrCharPoints.Values[i] = MotorolaXCMPRadioBase.SoftpotBytesToValue(softpotList[i]);
+                }
+            }
         }
     }
 }

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/APX/MotorolaAPX_TestTX_ReferenceOscillator.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/APX/MotorolaAPX_TestTX_ReferenceOscillator.cs
@@ -1,14 +1,50 @@
 ﻿using CSPID;
 using OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase;
+using OpenAutoBench_ng.Communication.Radio.Motorola.XPR;
 using OpenAutoBench_ng.OpenAutoBench;
+using System.Collections;
 
 namespace OpenAutoBench_ng.Communication.Radio.Motorola.APX
 {
     public class MotorolaAPX_TestTX_ReferenceOscillator : MotorolaXCMPRadio_TestTX_ReferenceOscillator
     {
-        public MotorolaAPX_TestTX_ReferenceOscillator(XCMPRadioTestParams testParams): base(testParams)
+        public MotorolaAPX_TestTX_ReferenceOscillator(XCMPRadioTestParams testParams) : base(testParams)
         {
             //
+        }
+
+        public async Task Setup()
+        {
+
+            await base.Setup();
+
+            //On FREON Radios, the frequencies and softpots can be obtained trough the READ_ALL_FREQ opcode
+            //For Mackiaw radios, READ_ALL_FREQ is not available, frequencies are obtained trough hardcoded lookup, and the softpots
+            //settings are recovered individually trough serveral XMCP request
+            if (MotorolaAPX_RefData.isFreon(Radio))
+            {
+                RefOscParams = Radio.SoftpotGetParams(SoftpotType.RefOsc);
+                if (RefOscParams.Frequencies.Length > 1)
+                    throw new Exception($"Ref Osc softpot returned more than 1 frequency, this is not currently supported!");
+            }
+            else
+            {
+                int[] frequencies = MotorolaAPX_RefData.TxFrequencies(Radio);
+                
+                RefOscParams.Frequencies = new int[1];
+                RefOscParams.Frequencies[0] = frequencies[frequencies.Length - 1];
+                
+                RefOscParams.Min = MotorolaXCMPRadioBase.SoftpotBytesToValue(Radio.SoftpotGetMinimum(SoftpotType.RefOsc));
+                RefOscParams.Max = MotorolaXCMPRadioBase.SoftpotBytesToValue(Radio.SoftpotGetMaximum(SoftpotType.RefOsc));
+                
+                RefOscParams.Values = new int[1];
+                RefOscParams.Values[0] = MotorolaXCMPRadioBase.SoftpotBytesToValue(Radio.SoftpotGetValue(SoftpotType.RefOsc));
+
+                RefOscParams.ByteLength = 2; 
+
+                List<byte[]> softpotList = Radio.SoftpotReadAll(SoftpotType.RefOsc, RefOscParams.ByteLength);
+                RefOscParams.Values[0] = MotorolaXCMPRadioBase.SoftpotBytesToValue(softpotList[0]);
+            }
         }
     }
 }

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/Astro25/MotorolaAstro25.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/Astro25/MotorolaAstro25.cs
@@ -52,7 +52,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.Astro25
             */
         }
 
-        public override int[] GetTXPowerPoints()
+       /* public override int[] GetTXPowerPoints()
         {
             SoftpotMessage msg = new SoftpotMessage(MsgType.REQUEST, SoftpotOperation.READ, SoftpotType.TxPowerCharPoint);
 
@@ -69,7 +69,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.Astro25
             returnVal[1] |= resp.Value[3];
 
             return returnVal;
-        }
+        }*/
         
     }
 }

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadioConstants.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadioConstants.cs
@@ -274,9 +274,13 @@
 
     public enum RxBerTestPattern : byte
     {
-        CCITT_V52 = 0x00,
-        P25_1011 = 0x01,
-        NONE = 0x02
+        DIGITAL_VOICE = 0x20,
+        P25_1011 = 0x21,
+        STD_HIGH_DEV = 0x23,
+        STD_LOW_DEV = 0x24,
+        STD_CCITT_V52 = 0x25,
+        STD_MOD_FIDELITY = 0x26,
+        APCO_SILENT =0x27
     }
 
     public enum RxBerTestMode : byte

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_P25BER.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_P25BER.cs
@@ -32,10 +32,18 @@ public class MotorolaXCMPRadio_TestRX_P25BER : IBaseTest
     {
         try
         {
+            Radio.SetReceiveConfig(XCMPRadioReceiveOption.STD_1011);
             for (int i= 0; i < TXFrequencies.Length; i++)
             {
                 int currFreq = TXFrequencies[i];
-                Radio.SetReceiveConfig(XCMPRadioReceiveOption.STD_1011);
+
+                // Skip any 7/800 TX-Only Freqs
+                if (currFreq is > 785000000 and < 850000000)
+                {
+                    Console.WriteLine($"Skipping BER test for frequency {currFreq / 1e6:0.000000} MHz, TX-only 7/800 MHz band");
+                    continue;
+                }
+
                 Radio.SetRXFrequency(currFreq, Bandwidth.BW_25kHz, RxModulation.C4FM);
                 await Instrument.SetTxFrequency(currFreq);
                 await Task.Delay(5000, Ct);

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_RSSI.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_RSSI.cs
@@ -49,12 +49,12 @@ public class MotorolaXCMPRadio_TestRX_RSSI : IBaseTest
                 await Instrument.SetTxFrequency(currFreq);
 
                 await Task.Delay(500, Ct);
-                await Instrument.GenerateSignal(-47); //For future version, this should be a customizable value
+                await Instrument.GenerateSignal(-50); //For future version, this should be a customizable value, Note: R2670 max gen level on RF I/O port is -50 dBm
                 await Task.Delay(1500, Ct);
                 byte rssi = Radio.GetStatus(StatusOperation.RSSI)[0];
 
                 await Instrument.StopGenerating();
-                Report.AddResult(OpenAutoBench.ResultType.RSSI, (float)rssi, 150, 150, 255, currFreq);
+                Report.AddResult(OpenAutoBench.ResultType.RSSI, (float)rssi, 150, 140, 255, currFreq);
                 LogCallback(String.Format("Measured RSSI at {0:0.000000} MHz: {1}", (currFreq / 1000000D), rssi));
             }
         }

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_DeviationBalance.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_DeviationBalance.cs
@@ -10,7 +10,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
         protected MotorolaXCMPRadioBase Radio;
 
         // Test Parameters
-        MotorolaXCMPRadioBase.SoftpotParams ModBalParams;
+        protected MotorolaXCMPRadioBase.SoftpotParams ModBalParams;
 
         protected int[] CharPoints;
 
@@ -26,11 +26,6 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
 
         public override async Task Setup()
         {
-            LogCallback(String.Format("Setting up for {0}", Name));
-
-            // Get softpot parameters
-            ModBalParams = Radio.SoftpotGetParams(SoftpotType.ModBalance);
-
             // Configure Instrument
             await Instrument.SetDisplay(InstrumentScreen.Monitor);
             await Task.Delay(1000, Ct);
@@ -46,7 +41,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
             Radio.SetTransmitConfig(XCMPRadioTransmitOption.DEVIATION_LOW);
             Radio.SetTransmitPower(TxPowerLevel.Low);
             Radio.Keyup();
-            Radio.SoftpotUpdate(SoftpotType.ModBalance, MotorolaXCMPRadioBase.SoftpotValueToBytes(softpotValue, 4));
+            Radio.SoftpotUpdate(SoftpotType.ModBalance, MotorolaXCMPRadioBase.SoftpotValueToBytes(softpotValue, ModBalParams.ByteLength));
             await Task.Delay(6000, Ct);
             float measDevLow = await Instrument.MeasureFMDeviation();
             measDevLow = (float)Math.Round(measDevLow);
@@ -57,7 +52,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
             // high tone
             Radio.SetTransmitConfig(XCMPRadioTransmitOption.DEVIATION_HIGH);
             Radio.Keyup();
-            Radio.SoftpotUpdate(SoftpotType.ModBalance, MotorolaXCMPRadioBase.SoftpotValueToBytes(softpotValue, 4));
+            Radio.SoftpotUpdate(SoftpotType.ModBalance, MotorolaXCMPRadioBase.SoftpotValueToBytes(softpotValue, ModBalParams.ByteLength));
             await Task.Delay(6000, Ct);
             float measDevHigh = await Instrument.MeasureFMDeviation();
             measDevHigh = (float)Math.Round(measDevHigh);
@@ -131,7 +126,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                     Radio.SetTransmitConfig(XCMPRadioTransmitOption.DEVIATION_LOW);
                     Radio.SetTransmitPower(TxPowerLevel.Low);
                     Radio.Keyup(TxMicrophone.InternalMuted);
-                    Radio.SoftpotUpdate(SoftpotType.ModBalance, MotorolaXCMPRadioBase.SoftpotValueToBytes(ModBalParams.Values[i], 4));
+                    Radio.SoftpotUpdate(SoftpotType.ModBalance, MotorolaXCMPRadioBase.SoftpotValueToBytes(ModBalParams.Values[i], ModBalParams.ByteLength));
                     await Task.Delay(6000, Ct);
                     float measDevLow = await Instrument.MeasureFMDeviation();
                     measDevLow = (float)Math.Round(measDevLow);
@@ -165,7 +160,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                     Radio.Keyup();
 
                     // Update initial softpot value
-                    Radio.SoftpotUpdate(SoftpotType.ModBalance, MotorolaXCMPRadioBase.SoftpotValueToBytes(ModBalParams.Values[i], 4));
+                    Radio.SoftpotUpdate(SoftpotType.ModBalance, MotorolaXCMPRadioBase.SoftpotValueToBytes(ModBalParams.Values[i], ModBalParams.ByteLength));
 
                     // Wait
                     await Task.Delay(2500, Ct);

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_PowerCharacterization.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_PowerCharacterization.cs
@@ -11,6 +11,8 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
 
         protected int[] CharPoints;
 
+        protected MotorolaXCMPRadioBase.SoftpotParams txPwrCharPoints;
+
         public MotorolaXCMPRadio_TestTX_PowerCharacterization(XCMPRadioTestParams testParams) : base("TX: Power Characterization", testParams.report, testParams.instrument, testParams.callback, testParams.ct)
         {
             Radio = testParams.radio;
@@ -30,18 +32,18 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
             await Task.Delay(1000, Ct);
             await Instrument.SetupTXPowerTest();
             await Task.Delay(1000, Ct);
-            CharPoints = Radio.GetTXPowerPoints();
-            Console.WriteLine($"Got TX power characterization points: {CharPoints.ToString()}");
+            //CharPoints = Radio.GetTXPowerPoints();
+            //Console.WriteLine($"Got TX power characterization points: {CharPoints.ToString()}");
         }
 
         public override async Task PerformTest()
         {
             try
             {
-                for (int i = 0; i < TXFrequencies.Length; i++)
+                for (int i = 0; i < txPwrCharPoints.Frequencies.Length; i++)
                 {
-                    Radio.SetTXFrequency(TXFrequencies[i], Bandwidth.BW_25kHz, TxDeviation.NoModulation);
-                    await Instrument.SetRxFrequency(TXFrequencies[i], testMode.ANALOG);
+                    Radio.SetTXFrequency(txPwrCharPoints.Frequencies[i], Bandwidth.BW_25kHz, TxDeviation.NoModulation);
+                    await Instrument.SetRxFrequency(txPwrCharPoints.Frequencies[i], testMode.ANALOG);
 
                     // Set Low Power
                     Radio.SetTransmitPower(TxPowerLevel.Low);
@@ -54,8 +56,8 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                     Radio.Dekey();
 
                     // TODO: Determine what the actual target output powers are based on the softpot settings
-                    Report.AddResult(OpenAutoBench.ResultType.TX_POWER, measPow, 0.0f, 0.75f, 7.0f, TXFrequencies[i]);
-                    LogCallback(String.Format("TX Low Power Point at {0}MHz: {1}w", (TXFrequencies[i] / 1000000D), measPow));
+                    Report.AddResult(OpenAutoBench.ResultType.TX_POWER, measPow, 0.0f, 0.75f, 7.0f, txPwrCharPoints.Frequencies[i]);
+                    LogCallback(String.Format("TX Low Power Point at {0}MHz: {1}w", (txPwrCharPoints.Frequencies[i] / 1000000D), measPow));
                     await Task.Delay(500, Ct);
 
                     // high power
@@ -69,8 +71,8 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                     Radio.Dekey();
 
                     // TODO: Determine what the actual target output powers are based on the softpot settings
-                    Report.AddResult(OpenAutoBench.ResultType.TX_POWER, measPow, 0.0f, 0.75f, 7.0f, TXFrequencies[i]);
-                    LogCallback(String.Format("TX High Power Point at {0}MHz: {1}w", (TXFrequencies[i] / 1000000D), measPow));
+                    Report.AddResult(OpenAutoBench.ResultType.TX_POWER, measPow, 0.0f, 0.75f, 7.0f, txPwrCharPoints.Frequencies[i]);
+                    LogCallback(String.Format("TX High Power Point at {0}MHz: {1}w", (txPwrCharPoints.Frequencies[i] / 1000000D), measPow));
                     
                     await Task.Delay(500, Ct);
                 }

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XPR/MotorolaXPR.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XPR/MotorolaXPR.cs
@@ -47,7 +47,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XPR
             testParams.radio.ResetRadio();
         }
 
-        public override int[] GetTXPowerPoints()
+       /* public override int[] GetTXPowerPoints()
         {
             SoftpotMessage msg = new SoftpotMessage(MsgType.REQUEST, SoftpotOperation.READ_ALL, SoftpotType.TxPowerCharPoint);
 
@@ -62,6 +62,6 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XPR
             }
 
             return returnVal;
-        }
+        }*/
     }
 }


### PR DESCRIPTION
MAJOR CHANGES
- The logic of the oscillator test/alignment, the power test, and the deviation balance test/alignment, as well as the setup routines were modified so that "AN" legacy radios are now supported.

- The logic of the oscillator test/alignment, the power test, and the deviation balance test/alignment, as well as the setup routines were modified so the APX specific code resides in the APX classes, instead of in the parent classes.

- On the R2670, when IF is set to narrow-band, the audio low pass filter will not go higher than 3KHz. This is introducing a measurement error as the high-tone in deviation balance test hits the 3KHz the filter roll-off. Test setups were changed so the IF is on wideband, and the 20KHz low-pass filter is enabled. Modulation measurement is also done using the averaged RMS mode for greater accuracy.

MINOR CHANGES & BUG FIXES
- Due to the implementation of averaging for the R2670, there's a time delay for the R2670 to return modulation metering. Serial connection timeout was changed from 3 sec to 5 seconds to prevent errors/exceptions.

- The RX BER test logic was adjusted to skip TX only frequencies.

- Implemented a static helper function to determine if a radio is a Freon radio based on the model number.

- Regression fix: Fixed several bugs that prevented OAB from reading a BER from radio.

- RxBERTestPattern Enum contained some errors, they were fixed, and other P25 Phase 1 Patterns were added.